### PR TITLE
Fix undefined name: co --> covar

### DIFF
--- a/Array/eigen_analysis.py
+++ b/Array/eigen_analysis.py
@@ -18,7 +18,7 @@ def getPrincipalComponents(centered, scale, region):
   arrays = centered.toArray()
 
   # Compute the covariance of the bands within the region.
-  co= arrays.reduceRegion({
+  covar = arrays.reduceRegion({
     'reducer': ee.Reducer.centeredCovariance(),
     'geometry': region,
     'scale': scale,


### PR DESCRIPTION
__co__ is an undefined name in this context which will raise NameError at runtime while __covar__ is used on the following line.  It looks like there was a global find and replace for "var " -> "".  The proposed solution tracks with similar code in [__Array/decorrelation_stretch.py__](https://github.com/giswqs/qgis-earthengine-examples/search?q=covar&unscoped_q=covar).