### PR TITLE
From Fusion Table to Earth Engine Snippet

### DIFF
--- a/FeatureCollection/buffer.py
+++ b/FeatureCollection/buffer.py
@@ -7,11 +7,9 @@ Display the area within 2 kilometers of any San Francisco BART station.
 import ee
 from ee_plugin import Map
 
-
 Map.setCenter(-122.4, 37.7, 11)
 
-bart_stations = ee.FeatureCollection(
-    'ft:1xCCZkVn8DIkB7i7RVkvsYWxAxsdsQZ6SbD9PCXw')
+bart_stations = ee.FeatureCollection('GOOGLE/EE/DEMOS/bart-locations')
 buffered = bart_stations.map(lambda f: f.buffer(2000))
 unioned = buffered.union()
 

--- a/FeatureCollection/count_features.py
+++ b/FeatureCollection/count_features.py
@@ -10,8 +10,7 @@ from ee_plugin import Map
 
 Map.setCenter(-122.39, 37.7857, 12)
 
-photos_near_sf = ee.FeatureCollection(
-    'ft:1qpKIcYQMBsXLA9RLWCaV9D0Hus2cMQHhI-ViKHo')
+photos_near_sf = ee.FeatureCollection('GOOGLE/EE/DEMOS/sf-photo-locations')
 bridge_photos = photos_near_sf.filter(
     ee.Filter().Or(ee.Filter.stringContains('title', 'Bridge'),
                    ee.Filter.stringContains('title', 'bridge')))

--- a/FeatureCollection/join.py
+++ b/FeatureCollection/join.py
@@ -9,8 +9,8 @@ from ee_plugin import Map
 
 Map.setCenter(-122.45, 37.75, 13)
 
-bart = ee.FeatureCollection('ft:1xCCZkVn8DIkB7i7RVkvsYWxAxsdsQZ6SbD9PCXw')
-parks = ee.FeatureCollection('ft:10KC6VfBWMUvNcuxU7mbSEg__F_4UVe9uDkCldBw')
+bart = ee.FeatureCollection('GOOGLE/EE/DEMOS/bart-locations')
+parks = ee.FeatureCollection('GOOGLE/EE/DEMOS/sf-parks')
 buffered_bart = bart.map(lambda f: f.buffer(2000))
 
 join_filter = ee.Filter.withinDistance(2000, '.geo', None, '.geo')

--- a/FeatureCollection/reverse_mask.py
+++ b/FeatureCollection/reverse_mask.py
@@ -9,7 +9,7 @@ from ee_plugin import Map
 
 Map.setCenter(-100, 40, 4)
 
-fc = (ee.FeatureCollection('ft:1Ec8IWsP8asxN-ywSqgXWMuBaxI6pPaeh6hC64lA')
+fc = (ee.FeatureCollection('RESOLVE/ECOREGIONS/2017')
       .filter(ee.Filter().eq('ECO_NAME', 'Great Basin shrub steppe')))
 
 # Start with a black image.

--- a/FeatureCollection/search_by_buffer_distance.py
+++ b/FeatureCollection/search_by_buffer_distance.py
@@ -11,8 +11,8 @@ from ee_plugin import Map
 
 Map.setCenter(-122.45, 37.75, 13)
 
-bart = ee.FeatureCollection('ft:1xCCZkVn8DIkB7i7RVkvsYWxAxsdsQZ6SbD9PCXw')
-parks = ee.FeatureCollection('ft:10KC6VfBWMUvNcuxU7mbSEg__F_4UVe9uDkCldBw')
+bart = ee.FeatureCollection('GOOGLE/EE/DEMOS/bart-locations')
+parks = ee.FeatureCollection('GOOGLE/EE/DEMOS/sf-parks')
 buffered_bart = bart.map(lambda f: f.buffer(2000))
 
 join_filter = ee.Filter.withinDistance(2000, '.geo', None, '.geo')


### PR DESCRIPTION
Hi @giswqs, in this PR I changed the Fusion Table ID by the corresponding Earth Engine Snippet. With these changes, the examples work again. Maybe you want to delete `fusion_table.py` and `from_fusion_table.py` since Google suspended completely the support to Fusion Table.
