### PR TITLE
Update deprecated cart classifier

### DIFF
--- a/MachineLearning/cart_classifier.py
+++ b/MachineLearning/cart_classifier.py
@@ -26,7 +26,7 @@ training = image.select(bands).sampleRegions(**{
 })
 
 # Train a CART classifier with default parameters.
-trained = ee.Classifier.cart().train(training, label, bands)
+trained = ee.Classifier.smileCart().train(training, label, bands)
 
 # Classify the image with the same bands used for training.
 classified = image.select(bands).classify(trained)


### PR DESCRIPTION
According to [this announcement](http://goo.gle/deprecated-classifiers), the cart classifier has been removed.

That's why, is necessary to update by smileCart

Classifier.cart  -> Classifier.smileCart